### PR TITLE
Machines & Robots Expac Ctd triggers & updates

### DIFF
--- a/common/game_rules/~~~~zzzzzzzzzzzzzzzzzzzzmerged_rules.txt
+++ b/common/game_rules/~~~~zzzzzzzzzzzzzzzzzzzzmerged_rules.txt
@@ -720,15 +720,8 @@ can_release_vassal_from_species = {
 					is_exp_tree_caretaker = yes
 				}
 			}
-			# Machines & Robot Expansion Continued
-			AND = {
-				has_trait = trait_machine_unit
-				prev.this = {
-					has_authority = auth_machine_intelligence
-					has_ascension_perk = oxr_mdlc_ap_distributed_multikernel
-					NOT = { has_civic = civic_machine_terminator }
-				}
-			}
+			# Machines & Robots Expansion Continued
+			oxr_mdlc_can_release_vassal_from_species = yes
 		}
 	}
 }
@@ -1981,6 +1974,8 @@ can_species_be_assembled = {
 			if = { limit = { has_trait = trait_KZ_VOY_magic_puppet }
 				KZ_VOY_can_assemble_magic_puppet = yes
 			}
+			# Machines & Robots Expansion Continued -- MAMP species cannot be assembled
+			has_oxr_mdlc_mamp_frame_base = no
 			# Vanilla
 			root = {
 				check_modifier_value = {

--- a/common/scripted_triggers/!-all_placeholder_triggers.txt
+++ b/common/scripted_triggers/!-all_placeholder_triggers.txt
@@ -543,3 +543,8 @@ is_planet_class_pc_y_star = { always = no }
 is_sparta_citizenship_full = { always = no }
 # Ethical Gestalts
 is_machine_assimilator = { always = no }
+# Machines & Robots Expansion Continued
+has_machines_robots_expac_continued = { always = no }  # Check for this mod
+oxr_mdlc_can_release_vassal_from_species = { always = no }
+has_oxr_mdlc_mamp_frame_base = { always = no }  # Trait check
+xvcv_mdlc_is_non_gate_mega = { always = no }  # yes if it's a non-gate mega from this mod

--- a/common/scripted_triggers/~~~~zzzzzzmerg_00_triggers.txt
+++ b/common/scripted_triggers/~~~~zzzzzzmerg_00_triggers.txt
@@ -253,6 +253,8 @@ can_be_leader = {
 				}
 			}
 		}
+		# Machines & Robots Expansion Continued
+		has_oxr_mdlc_mamp_frame_base = no
 	}
 }
 
@@ -320,9 +322,8 @@ has_any_megastructure_in_empire = {
 				is_megastructure_type = orbital_ring_restored
 				# Gigastructural Engineering & More
 				is_kilostructure = yes
-				# Machine & Robot Expansion
-				is_megastructure_type = xvcv_mdlc_planet_cracker_incomplete
-				is_megastructure_type = xvcv_mdlc_planet_cracker
+				# Machines & Robots Expansion Continued
+				xvcv_mdlc_is_non_gate_mega = yes
 			}
 		}
 	}


### PR DESCRIPTION
Hi Inny, these are some changes I'm proposing for compatibility between MREC and Merger.

While MREC is not yet ready for 3.12, I had to get at these changes at some point and now seemed like a good time. I do want to get these in to Merger before releasing my 3.12 patch for MREC.

Let me know what you think -- I introduced `xvcv_mdlc_is_non_gate_mega` in this commit in MREC : https://github.com/openly-retro/stellaris-machine-robot-expansion/blob/85d64755378c621135bc2fb1a55c70019b9c2109/common/scripted_triggers/oxr_mdlc_merger_of_rules_triggers_compat.txt 

```
xvcv_mdlc_is_non_gate_mega = {
	OR = {
		is_megastructure_type = xvcv_mdlc_planet_cracker_incomplete
		is_megastructure_type = xvcv_mdlc_planet_cracker
	}
}
```

 The above link has other triggers I've added.

If you see something in this change set that won't work, please let me know.